### PR TITLE
Uppdatering av ftp-mjukvara

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     name: Push files
     steps:
       - name: Get latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: FTP Deploy
         uses: SamKirkland/FTP-Deploy-Action@4.3.4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
         
       - name: FTP Deploy
-        uses: SamKirkland/FTP-Deploy-Action@4.3.2
+        uses: SamKirkland/FTP-Deploy-Action@4.3.4
         with:
           # ftp server
           server: ftpcluster.loopia.se


### PR DESCRIPTION
Den nuvarande versionen av FTP-Deploy-Action använder sig av en version av Node som håller på att deprecieras i github actions. Detta kan åskådas i loggarna.